### PR TITLE
Fix race condition in audio playback

### DIFF
--- a/animal-sounds.js
+++ b/animal-sounds.js
@@ -154,21 +154,23 @@ class AnimalSounds {
             this.currentAudio = new Audio(soundUrl);
             this.currentAudio.volume = 0.7;
             
+            // Set onended callback BEFORE calling play() to prevent race condition
+            this.currentAudio.onended = () => {
+                this.pronounceAnimal(animalName);
+            };
+            
             const playPromise = this.currentAudio.play();
             
             if (playPromise !== undefined) {
                 playPromise.then(() => {
-                    // Sound played successfully
-                    this.currentAudio.onended = () => {
-                        this.pronounceAnimal(animalName);
-                    };
+                    // Sound played successfully - onended callback already set
                 }).catch(error => {
                     console.log('Audio playback failed, using fallback:', error);
                     this.fallbackToSynthesis(animalName);
                 });
             } else {
-                // Fallback for older browsers
-                this.fallbackToSynthesis(animalName);
+                // Older browsers - onended callback is already set above
+                // Audio will play and trigger the callback when finished
             }
         } else {
             // No audio file available, use synthesis


### PR DESCRIPTION
Fix race condition and incorrect fallback in `playAnimalSound` by setting `onended` before `play()`.

The `currentAudio.onended` callback was set *after* `currentAudio.play()` was called, which could cause short audio clips to finish before `onended` was registered, preventing `pronounceAnimal()` from being called. Additionally, older browser fallback logic was unnecessarily skipping real audio.